### PR TITLE
closes #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,39 @@
-# Welcome to Keyp Frontend-Components
+<h1 align="center"><img width="600" style="border-radius: 30px;" src="https://raw.githubusercontent.com/UseKeyp/.github/main/Keyp-Logo-Color.svg"/></h1>
+<h1 align="center">Welcome to Keyp Frontend-Components 👋</h1>
+<p align="center">
+  <a href="#" target="_blank">
+    <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue.svg" />
+  </a>
+  <a href="https://twitter.com/UseKeyp" target="_blank">
+    <img alt="Twitter: UseKeyp" src="https://img.shields.io/twitter/follow/UseKeyp.svg?style=social" />
+  </a>
+</p>
 
-> Frontend component packages for various applications
+> UI library package for various applications
 
-Our components are in the `components-soft-ui` directory and our Tailwind presets are in the `tailwind-presets`
-directory.
+Our components are in the `ui-library` directory.
+
+## Usage 📖
+
+1. Install necessary dependencies
+
+```bash
+ yarn add
+```
+
+## Resources 🧑‍💻
+
+This repo is configured to use [Publish PR Packages](https://github.com/marketplace/actions/publish-pr-packages) to auto-publish packages
+for each pull request. Make sure you rename the template package name in `ci-release.yml` to your own package name.
+
+## License 📝
+
+Copyright © 2023 Nifty Chess, Inc.<br />
+This project is MIT licensed.
+
+[sponsor-keyp]: https://UseKeyp.com
+
+=================================================================================
 
 ## Usage 📖
 
@@ -56,7 +86,3 @@ You can unlink a package by running `yarn unlink <package-name>`.
 - [Keyp Frontend Components](https://github.com/UseKeyp/frontend-components)
 - [Yarn Link Docs](https://yarnpkg.com/cli/link)
 - [Surge](https://surge.sh/)
-
-## License 📝
-
-Copyright © 2023 Nifty Chess, Inc.<br /> 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center"><img width="600" style="border-radius: 30px;" src="https://raw.githubusercontent.com/UseKeyp/.github/main/Keyp-Logo-Color.svg"/></h1>
-<h1 align="center">Welcome to Keyp Frontend-Components 👋</h1>
+<h1 align="center">Welcome to Keyp UI Library 👋</h1>
 <p align="center">
   <a href="#" target="_blank">
     <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue.svg" />
@@ -15,7 +15,7 @@ Our components are in the `ui-library` directory.
 
 ## Links
 
-Published from dev branch: https://keyp-ui-library-dev.surge.sh/
+Published from dev branch: https://keyp-ui-library-dev.surge.sh/  
 Published from main branch: https://keyp-ui-library.surge.sh/
 
 ## Usage 📖
@@ -37,14 +37,12 @@ While testing, if you need a link to send to the design team you can easily depl
 2. Run `styleguidist build` to generate the styleguide directory with the bundled assets for deploy
 3. Run `surge` and point to the styleguide folder
 4. Should look like `/YOUR_LOCAL_PATH/ui-library/styleguide`
-5. Choose https://keyp-frontend-components.surge.sh/ as the domain to deploy the site if you want to deploy a new production build (you can create any other name for the domain if you want to deploy a test build to share with someone)
+5. Choose https://keyp-ui-library.surge.sh/ as the domain to deploy the site if you want to deploy a new production build (you can create any other name for the domain if you want to deploy a test build to share with someone)
 6. If you're unable to deploy to the production domain, send your email to Jacob so he can add you as a collaborator
 
 ## Resources 🧑‍💻
 
 - [Surge](https://surge.sh/)
-
-This repo is configured to use [Publish PR Packages](https://github.com/marketplace/actions/publish-pr-packages) to auto-publish packages for each pull request. Make sure you rename the template package name in `ci-release.yml` to your own package name.
 
 ## License 📝
 

--- a/README.md
+++ b/README.md
@@ -15,19 +15,31 @@ Our components are in the `ui-library` directory.
 
 ## Usage 📖
 
-1. Install necessary dependencies
+1. Clone the repo and run `yarn install` to install the necessary dependencies. Make sure you're using a recent version of node (>= 16.0.0)
+2. In the same directory, run `yarn tailwindcss`. This script ensures our Tailwind styles are built and available to the styleguidist server.
+3. Navigate to the root directory of `ui-library` and run `yarn start`. This script starts the styleguidist
+   server.
+4. Your server should now be running successfully!
 
-- yarn add @usekeyp/ui-library
-- Override your webpack.config.js to add nessecary loaders
-  `yarn eject`
-- add taiwindcss and tailwind.config.cjs
-- in tailwind.config.cjs you have to merge tailwind.config from node_modules/@usekeyp
-- run tailwind build to make css folder
+### Deploying with Surge
+
+Surge is a static web publishing service that lets us easily deploy our frontend components to a live URL.
+Currently, our frontend components are deployed to https://keyp-frontend-components.surge.sh/
+While testing, if you need a link to send to the design team you can easily deploy to a different link. However, we will keep this link as the code representative of our components currently in production.
+<br /><br />This is how you can deploy to surge:
+
+1. CD into the ui-library folder
+2. Run `styleguidist build` to generate the styleguide directory with the bundled assets for deploy
+3. Run `surge` and point to the styleguide folder
+4. Should look like `/YOUR_LOCAL_PATH/ui-library/styleguide`
+5. Choose https://keyp-frontend-components.surge.sh/ as the domain to deploy the site if you want to deploy a new production build (you can create any other name for the domain if you want to deploy a test build to share with someone)
+6. If you're unable to deploy to the production domain, send your email to Jacob so he can add you as a collaborator
 
 ## Resources 🧑‍💻
 
-This repo is configured to use [Publish PR Packages](https://github.com/marketplace/actions/publish-pr-packages) to auto-publish packages
-for each pull request. Make sure you rename the template package name in `ci-release.yml` to your own package name.
+- [Surge](https://surge.sh/)
+
+This repo is configured to use [Publish PR Packages](https://github.com/marketplace/actions/publish-pr-packages) to auto-publish packages for each pull request. Make sure you rename the template package name in `ci-release.yml` to your own package name.
 
 ## License 📝
 
@@ -35,57 +47,3 @@ Copyright © 2023 Nifty Chess, Inc.<br />
 This project is MIT licensed.
 
 [sponsor-keyp]: https://UseKeyp.com
-
-=================================================================================
-
-## Usage 📖
-
-1. Clone the repo and run `yarn install` to install the necessary dependencies. Make sure you're using a recent version of node (>= 16.0.0)
-2. Navigate to the root directory of `components-soft-ui` and run `yarn start`. This script starts the styleguidist
-   server.
-3. In the same directory, run `yarn tailwindcss`. This script ensures our Tailwind styles are built and available to the
-   styleguidist server.
-4. Your server should now be running successfully!
-
-### Deploying with Surge
-
-Surge is a static web publishing service that lets us easily deploy our frontend components to a live URL.
-Currently, our frontend components are deployed to https://keyp-frontend-components.surge.sh/
-While testing, if you need a link to send to the design team you can easily deploy to a different link. However,
-we will keep this link as the code representative of our components currently in production.
-<br /><br />This is how you can deploy to surge:
-
-1. CD into the components-soft-ui folder
-2. Run `styleguidist build` to generate the styleguide directory with the bundled assets for deploy
-3. Run `surge` and point to the styleguide folder
-4. Should look like `/YOUR_LOCAL_PATH/frontend-components/components-soft-ui/styleguide`
-5. Choose https://keyp-frontend-components.surge.sh/ as the domain to deploy the site if you want to deploy a new
-   production build (you can create any other name for the domain if you want to deploy a test build to share with
-   someone)
-6. If you're unable to deploy to the production domain, send your email to Jacob so he can add you as a collaborator
-
-### Using Yarn Link
-
-To use `@usekeyp/components-soft-ui` and `@usekeyp/tailwind-presets` with other repositories locally, you'll have to use
-yarn link. Yarn link is a command that allows you to create a symlink from a local package to another location on your
-machine. This is useful when you are working on multiple packages that depend on each other and you want to test your
-changes in one package while developing another.
-To use yarn link, follow these steps:
-
-Navigate to the root directory of the package that you want to create a symlink for. For example, while in
-frontend-components, here's how to create a symlink for @usekeyp/components-soft-ui:
-
-1. First enter `cd components-soft-ui` in your terminal.
-2. Run the command `yarn link`. This will create a symlink for `@usekeyp/components-soft-ui` in the global yarn package
-   registry.
-3. Navigate to the root directory of the package that depends on `@usekeyp/components-soft-ui`.
-4. Run the command `yarn link @usekeyp/components-soft-ui`. This will create a symlink from the dependent package to the
-   linked package.
-
-You can unlink a package by running `yarn unlink <package-name>`.
-
-## Resources 🧑‍💻
-
-- [Keyp Frontend Components](https://github.com/UseKeyp/frontend-components)
-- [Yarn Link Docs](https://yarnpkg.com/cli/link)
-- [Surge](https://surge.sh/)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ Our components are in the `ui-library` directory.
 
 1. Install necessary dependencies
 
-```bash
- yarn add
-```
+- yarn add @usekeyp/ui-library
+- Override your webpack.config.js to add nessecary loaders
+  `yarn eject`
+- add taiwindcss and tailwind.config.cjs
+- in tailwind.config.cjs you have to merge tailwind.config from node_modules/@usekeyp
+- run tailwind build to make css folder
 
 ## Resources 🧑‍💻
 

--- a/packages/ui-library/README.md
+++ b/packages/ui-library/README.md
@@ -1,5 +1,5 @@
 <h1 align="center"><img width="600" style="border-radius: 30px;" src="https://raw.githubusercontent.com/UseKeyp/.github/main/Keyp-Logo-Color.svg"/></h1>
-<h1 align="center">Welcome to Keyp Frontend-Components 👋</h1>
+<h1 align="center">Welcome to Keyp UI Library 👋</h1>
 <p align="center">
   <a href="#" target="_blank">
     <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue.svg" />

--- a/packages/ui-library/README.md
+++ b/packages/ui-library/README.md
@@ -16,13 +16,13 @@
 1.  Add package to your project
     `yarn add @usekeyp/ui-library`
 
-2.  Install necessary dependencies
+2.  Install and configure necessary dependencies
 
-    2.1. Configure the webpack
+    2.1. Configure Webpack
 
-    - `yarn eject` to make changes to a webpack
+    - Run `yarn ejec`t to customize the Webpack configuration.
 
-    - Include new path for uiLibrary in webpack.config.js
+    - Update `webpack.config.js` by including the new path for the UI Library:
 
     ```
         {
@@ -56,7 +56,7 @@
         },
     ```
 
-    - in path.js add uiLibrary path
+    - Add the UI Library path in `paths.js`:
 
     ```
         module.exports = {
@@ -67,7 +67,7 @@
 
     2.2. Add Tailwind CSS
 
-    - Ensure Tailwind CSS is properly configured in your application. Here's an example of what that should look like:
+    - Ensure Tailwind CSS is properly configured in your application to merge tailwind.config.js files. Here's an example of what that should look like:
 
     ```
         const packageTailwindConfig = require('@usekeyp/ui-library/tailwind.config.cjs');
@@ -90,7 +90,7 @@
     `npx tailwindcss -i ./src/index.css -o ./dist/output.css --watch -c tailwind.config.js`
 
 4.  Add output.css to App.js
-5.  Use components in your project
+5.  Utilize components in your project
 
 ```
 import { LoginPortal } from "@usekeyp/ui-library";

--- a/packages/ui-library/README.md
+++ b/packages/ui-library/README.md
@@ -1,11 +1,73 @@
-# `ui-library`
+<h1 align="center"><img width="600" style="border-radius: 30px;" src="https://raw.githubusercontent.com/UseKeyp/.github/main/Keyp-Logo-Color.svg"/></h1>
+<h1 align="center">Welcome to Keyp Frontend-Components 👋</h1>
+<p align="center">
+  <a href="#" target="_blank">
+    <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue.svg" />
+  </a>
+  <a href="https://twitter.com/UseKeyp" target="_blank">
+    <img alt="Twitter: UseKeyp" src="https://img.shields.io/twitter/follow/UseKeyp.svg?style=social" />
+  </a>
+</p>
 
-> TODO: description
+> UI library package for various applications
 
-## Usage
+## Usage 📖
+
+1. Add package to your project
+   `yarn add @usekeyp/ui-library`
+
+2. Install necessary dependencies
+
+- Add babel-loader to the webpack
+  `yarn eject` to configure webpack
+
+- Add Tailwind CSS
+- Ensure Tailwind CSS is properly configured in your application. Here's an example of what that should look like:
 
 ```
-const uiLibrary = require('ui-library');
+const packageTailwindConfig = require('@usekeyp/ui-library/tailwind.config.cjs');
+const { merge } = require('lodash');
 
-// TODO: DEMONSTRATE API
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}",
+    "./node_modules/@usekeyp/ui-library/src/**/*.{js,jsx,ts,tsx,md}",
+  ],
+  theme: merge({}, packageTailwindConfig.theme, {
+    extend: {},
+  }),
+  plugins: packageTailwindConfig.plugins.concat([]),
+};
 ```
+
+3. Build the output.css file
+   Example: `npx tailwindcss -i ./src/index.css -o ./dist/output.css --watch -c tailwind.config.js"`
+
+4. Use it in your project
+
+```
+import { LoginPortal } from "@usekeyp/ui-library";
+
+const LoginPage = () => {
+
+  const onClick = (providerType) => {
+   // custom auth logic depending on the app
+  }
+
+  return (<><LoginPortal onClick={onClick} /><>)
+}
+
+```
+
+## Resources 🧑‍💻
+
+- [Tailwind CSS Documentation](https://tailwindcss.com/docs/installation)
+- [Add babel-loader to a webpack](https://webpack.js.org/loaders/babel-loader/)
+
+## License 📝
+
+Copyright © 2023 Nifty Chess, Inc.<br />
+This project is MIT licensed.
+
+[sponsor-keyp]: https://UseKeyp.com

--- a/packages/ui-library/README.md
+++ b/packages/ui-library/README.md
@@ -24,7 +24,7 @@
 
     - Update `webpack.config.js` by including the new path for the UI Library:
 
-    ```
+    ```js
         {
             test: /\.(js|mjs|jsx|ts|tsx)$/,
             include: paths.uiLibrary,
@@ -58,7 +58,7 @@
 
     - Add the UI Library path in `paths.js`:
 
-    ```
+    ```js
         module.exports = {
             ...,
             uiLibrary: resolveApp("./node_modules/@usekeyp/ui-library/"),
@@ -69,20 +69,20 @@
 
     - Ensure Tailwind CSS is properly configured in your application to merge tailwind.config.js files. Here's an example of what that should look like:
 
-    ```
-        const packageTailwindConfig = require('@usekeyp/ui-library/tailwind.config.cjs');
-        const { merge } = require('lodash')
-        /** @type {import('tailwindcss').Config} */
-        module.exports = {
-        content: [
-            "./src/**/*.{js,jsx,ts,tsx}",
-            "./node_modules/@usekeyp/ui-library/src/**/*.{js,jsx,ts,tsx,md}",
-        ],
-        theme: merge({}, packageTailwindConfig.theme, {
-            extend: {},
-        }),
-        plugins: packageTailwindConfig.plugins.concat([]),
-        };
+    ```js
+    const packageTailwindConfig = require("@usekeyp/ui-library/tailwind.config.cjs");
+    const { merge } = require("lodash");
+    /** @type {import('tailwindcss').Config} */
+    module.exports = {
+      content: [
+        "./src/**/*.{js,jsx,ts,tsx}",
+        "./node_modules/@usekeyp/ui-library/src/**/*.{js,jsx,ts,tsx,md}",
+      ],
+      theme: merge({}, packageTailwindConfig.theme, {
+        extend: {},
+      }),
+      plugins: packageTailwindConfig.plugins.concat([]),
+    };
     ```
 
 3.  Build the output.css file.  
@@ -92,7 +92,7 @@
 4.  Add output.css to App.js.
 5.  Utilize components in your project:
 
-```
+```js
 import { LoginPortal } from "@usekeyp/ui-library";
 
 const LoginPage = () => {

--- a/packages/ui-library/README.md
+++ b/packages/ui-library/README.md
@@ -13,38 +13,84 @@
 
 ## Usage 📖
 
-1. Add package to your project
-   `yarn add @usekeyp/ui-library`
+1.  Add package to your project
+    `yarn add @usekeyp/ui-library`
 
-2. Install necessary dependencies
+2.  Install necessary dependencies
 
-- Add babel-loader to the webpack
-  `yarn eject` to configure webpack
+    2.1. Configure the webpack
 
-- Add Tailwind CSS
-- Ensure Tailwind CSS is properly configured in your application. Here's an example of what that should look like:
+    - `yarn eject` to make changes to a webpack
 
-```
-const packageTailwindConfig = require('@usekeyp/ui-library/tailwind.config.cjs');
-const { merge } = require('lodash');
+    - Include new path for uiLibrary in webpack.config.js
 
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: [
-    "./src/**/*.{js,jsx,ts,tsx}",
-    "./node_modules/@usekeyp/ui-library/src/**/*.{js,jsx,ts,tsx,md}",
-  ],
-  theme: merge({}, packageTailwindConfig.theme, {
-    extend: {},
-  }),
-  plugins: packageTailwindConfig.plugins.concat([]),
-};
-```
+    ```
+        {
+            test: /\.(js|mjs|jsx|ts|tsx)$/,
+            include: paths.uiLibrary,
+            loader: require.resolve("babel-loader"),
+            options: {
+            customize: require.resolve(
+                "babel-preset-react-app/webpack-overrides"
+            ),
+            presets: [
+                [
+                require.resolve("babel-preset-react-app"),
+                {
+                    runtime: hasJsxRuntime ? "automatic" : "classic",
+                },
+                ]
+            plugins: [
+                isEnvDevelopment &&
+                shouldUseReactRefresh &&
+                require.resolve("react-refresh/babel"),
+            ].filter(Boolean),
+            // This is a feature of `babel-loader` for webpack (not Babel itself).
+            // It enables caching results in ./node_modules/.cache/babel-loader/
+            // directory for faster rebuilds.
+            cacheDirectory: true,
+            // See #6846 for context on why cacheCompression is disabled
+            cacheCompression: false,
+            compact: isEnvProduction,
+            },
+        },
+    ```
 
-3. Build the output.css file
-   Example: `npx tailwindcss -i ./src/index.css -o ./dist/output.css --watch -c tailwind.config.js"`
+    - in path.js add uiLibrary path
 
-4. Use it in your project
+    ```
+        module.exports = {
+            ...,
+            uiLibrary: resolveApp("./node_modules/@usekeyp/ui-library/"),
+        };
+    ```
+
+    2.2. Add Tailwind CSS
+
+    - Ensure Tailwind CSS is properly configured in your application. Here's an example of what that should look like:
+
+    ```
+        const packageTailwindConfig = require('@usekeyp/ui-library/tailwind.config.cjs');
+        const { merge } = require('lodash')
+        /** @type {import('tailwindcss').Config} */
+        module.exports = {
+        content: [
+            "./src/**/*.{js,jsx,ts,tsx}",
+            "./node_modules/@usekeyp/ui-library/src/**/*.{js,jsx,ts,tsx,md}",
+        ],
+        theme: merge({}, packageTailwindConfig.theme, {
+            extend: {},
+        }),
+        plugins: packageTailwindConfig.plugins.concat([]),
+        };
+    ```
+
+3.  Build the output.css file.  
+    Example:  
+    `npx tailwindcss -i ./src/index.css -o ./dist/output.css --watch -c tailwind.config.js`
+
+4.  Add output.css to App.js
+5.  Use components in your project
 
 ```
 import { LoginPortal } from "@usekeyp/ui-library";

--- a/packages/ui-library/README.md
+++ b/packages/ui-library/README.md
@@ -13,14 +13,14 @@
 
 ## Usage 📖
 
-1.  Add package to your project
+1.  Add package to your project:  
     `yarn add @usekeyp/ui-library`
 
-2.  Install and configure necessary dependencies
+2.  Install and configure necessary dependencies.
 
-    2.1. Configure Webpack
+    2.1. Configure Webpack:
 
-    - Run `yarn ejec`t to customize the Webpack configuration.
+    - Run `yarn eject` to customize the Webpack configuration.
 
     - Update `webpack.config.js` by including the new path for the UI Library:
 
@@ -65,7 +65,7 @@
         };
     ```
 
-    2.2. Add Tailwind CSS
+    2.2. Add Tailwind CSS.
 
     - Ensure Tailwind CSS is properly configured in your application to merge tailwind.config.js files. Here's an example of what that should look like:
 
@@ -89,8 +89,8 @@
     Example:  
     `npx tailwindcss -i ./src/index.css -o ./dist/output.css --watch -c tailwind.config.js`
 
-4.  Add output.css to App.js
-5.  Utilize components in your project
+4.  Add output.css to App.js.
+5.  Utilize components in your project:
 
 ```
 import { LoginPortal } from "@usekeyp/ui-library";
@@ -109,7 +109,6 @@ const LoginPage = () => {
 ## Resources 🧑‍💻
 
 - [Tailwind CSS Documentation](https://tailwindcss.com/docs/installation)
-- [Add babel-loader to a webpack](https://webpack.js.org/loaders/babel-loader/)
 
 ## License 📝
 


### PR DESCRIPTION
### What I did
- updated Readme for developers (in root directory)
- updated Readme inside `ui-library` package
- cloned and created branch from [keyp-docs](https://github.com/UseKeyp/usekeyp-docs), added page `UI Library` with usage information
- removed section about UI from OAUTH

### Next steps
- create PR in [keyp-docs](https://github.com/UseKeyp/usekeyp-docs)

### Comments
- I think that the usage of this package is not easy and I am willing to try to prebuild at least css file on the package side, so user don't have to merge tailwind.config.js files but use prebuilt css classes
- I read about prebuilding js files for creating react components library, can try it too, so user don't have to eject and edit webpack on their side

### Screenshot of how keyp-docs UI Library page will look like

<img width="1352" alt="top-page" src="https://user-images.githubusercontent.com/36742189/231538652-834af7b3-b39c-4e0d-9193-05b459c205fa.png">

<img width="1448" alt="bottom-page" src="https://user-images.githubusercontent.com/36742189/231538718-39839b05-4ad6-46bc-9b41-4cdb485a6805.png">



