### PR TITLE
Remove redwood dependency

### DIFF
--- a/packages/ui-kit/README.md
+++ b/packages/ui-kit/README.md
@@ -58,7 +58,7 @@
       module.exports = {
         content: [
           "./src/**/*.{js,jsx,ts,tsx}",
-          "./node_modules/@usekeyp/ui-kit/lib/**/*.{js,jsx,ts,tsx,md}",
+          "./node_modules/@usekeyp/ui-kit/lib/**/**/*.{js,jsx,ts,tsx,md}",
         ],
         plugins: [require("@usekeyp/ui-kit/plugin")],
         // ...
@@ -73,7 +73,7 @@
         content: [
           "./pages/**/*.{js, jsx, ts,tsx}",
           "./public/**/*.html",
-          "./node_modules/@usekeyp/ui-kit/lib/**/*.{js,jsx,ts,tsx,md}",
+          "./node_modules/@usekeyp/ui-kit/lib/**/**/*.{js,jsx,ts,tsx,md}",
         ],
         plugins: [require("@usekeyp/ui-kit/plugin")],
         // ...

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -22,7 +22,6 @@
     "test": "node ./__tests__/ui-kit.test.js"
   },
   "dependencies": {
-    "@redwoodjs/router": "^3.3.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "styleguidist server --config styleguide.config.cjs",
     "tailwindcss": "tailwindcss -i ./src/index.css -o ./dist/output.css --watch -c tailwind.config.js",
-    "build": "yarn tailwindcss && styleguidist build --config styleguide.config.cjs && babel --config-file ./babel.config.js src -d lib",
+    "build": "tailwindcss -i ./src/index.css -o ./dist/output.css && styleguidist build --config styleguide.config.cjs && babel --config-file ./babel.config.js src -d lib",
     "pre-publish": "babel --config-file ./babel.config.js src -d lib ",
     "test": "node ./__tests__/ui-kit.test.js"
   },

--- a/packages/ui-kit/src/components/Button/Button.jsx
+++ b/packages/ui-kit/src/components/Button/Button.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "@redwoodjs/router";
 import PropTypes from "prop-types";
 
 /**
@@ -36,31 +35,6 @@ const Button = ({
   ...rest
 }) => {
   const Element = href ? "a" : "button";
-  if (to) {
-    return (
-      <Link
-        className={`removeFlickering flex justify-center items-center group text-center text-lg leading-button font-bold tracking-wide rounded-[6px]  
-            ${textColor ? textColor : "text-white"} 
-            ${size === "regular" && !fluid ? "h-[48px] w-[200px]" : ""}
-            ${size === "small" && !fluid ? "h-[32px] w-[200px]" : ""}
-            ${size === "square" && !fluid ? "h-[48px] w-[48px]" : ""}
-            ${fluid && "h-[48px] w-full"}
-            ${borderColor ? borderColor : ""}
-            ${classNameVariant ? classNameVariant : ""}
-            `}
-        onClick={() => onClick()}
-        data-variant={variant}
-        data-size={size}
-        data-textcolor={textColor}
-        data-fluid={String(fluid)}
-        to={to}
-        {...rest}
-      >
-        {label || children}
-      </Link>
-    );
-  }
-
   return (
     <Element
       className={`removeFlickering flex items-center group text-center text-lg leading-button font-bold tracking-wide rounded-[6px]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1049,14 +1049,6 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime-corejs3@7.20.6":
-  version "7.20.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.20.6.tgz#63dae945963539ab0ad578efbf3eff271e7067ae"
-  integrity sha512-tqeujPiuEfcH067mx+7otTQWROVMKHXEaOQcAeNV5dDdbPWvPcFA8/W9LXw2NfjNmOetqLl03dfnG2WALPlsRQ==
-  dependencies:
-    core-js-pure "^3.25.1"
-    regenerator-runtime "^0.13.11"
-
 "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.20.7", "@babel/runtime@^7.3.1", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.5.tgz#8492dddda9644ae3bda3b45eabe87382caee7200"
@@ -2139,41 +2131,6 @@
   version "2.11.7"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.7.tgz#ccab5c8f7dc557a52ca3288c10075c9ccd37fff7"
   integrity sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==
-
-"@reach/skip-nav@0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@reach/skip-nav/-/skip-nav-0.16.0.tgz#dec34f3a40a1e804e05647646aacab0ffd73b24d"
-  integrity sha512-SY4PdNx+hQHbeOr/+qLc+QXdRt9NTVlt0r737bOqY1WURGBIEN9sGgsmIsHluP1/bQuAe0JKdOJ/tXiwQ3Z3ug==
-  dependencies:
-    "@reach/utils" "0.16.0"
-    tslib "^2.3.0"
-
-"@reach/utils@0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
-  integrity sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==
-  dependencies:
-    tiny-warning "^1.0.3"
-    tslib "^2.3.0"
-
-"@redwoodjs/auth@3.8.0":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/auth/-/auth-3.8.0.tgz#5c0dbcf9910ebebb2e9c67667399a79c0af2bd70"
-  integrity sha512-SM08Ncm4k91+nnzEjy8mpY3iUv2n0YUU0Nslt3v7JRistOeUm+Zyz2wam/08STIIX2aO3u89IeRvcSAn2w+cOw==
-  dependencies:
-    "@babel/runtime-corejs3" "7.20.6"
-    core-js "3.26.1"
-
-"@redwoodjs/router@^3.3.0":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/router/-/router-3.8.0.tgz#6c0f3e7a855736823befe018e1ff1cb93aca7ab4"
-  integrity sha512-a0H48zsJ+mm1xPBvCgg/n0RL7bP+vQ1H41krTCtLokmk4FtloZLRpQnUzXqNKHKAZ+h3BIa+UYFhR9vsQi44jw==
-  dependencies:
-    "@babel/runtime-corejs3" "7.20.6"
-    "@reach/skip-nav" "0.16.0"
-    "@redwoodjs/auth" "3.8.0"
-    core-js "3.26.1"
-    lodash.isequal "4.5.0"
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
@@ -4552,15 +4509,10 @@ core-js-compat@^3.25.1:
   dependencies:
     browserslist "^4.21.5"
 
-core-js-pure@^3.23.3, core-js-pure@^3.25.1:
+core-js-pure@^3.23.3:
   version "3.30.1"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.30.1.tgz#7d93dc89e7d47b8ef05d7e79f507b0e99ea77eec"
   integrity sha512-nXBEVpmUnNRhz83cHd9JRQC52cTMcuXAmR56+9dSMpRdpeA4I1PX6yjmhd71Eyc/wXNsdBdUDIj1QTIeZpU5Tg==
-
-core-js@3.26.1:
-  version "3.26.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.26.1.tgz#7a9816dabd9ee846c1c0fe0e8fcad68f3709134e"
-  integrity sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==
 
 core-js@^3.19.2, core-js@^3.6.4:
   version "3.30.1"
@@ -8551,11 +8503,6 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
-
-lodash.isequal@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"
@@ -12740,7 +12687,7 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
-tiny-warning@^1.0.2, tiny-warning@^1.0.3:
+tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==


### PR DESCRIPTION
closes #29  

## What I did
- fixed documentation (we had the wrong path in instruction)
- fixed `build` command (couldn't build styleguide and lib because of `watch` from `tailwindcss` command)
- removed redwood dependencies from package.json and yarn.lock
- removed Link element from Button