### PR TITLE
Issue #1 [SDK] setup

### DIFF
--- a/examples/next-app/.env.example
+++ b/examples/next-app/.env.example
@@ -1,8 +1,10 @@
 # Your application Client ID from https://dev.usekeyp.com
 NEXT_PUBLIC_KEYP_CLIENT_ID=
 
-NEXTAUTH_URL=http://localhost:3000 # Domain where you serve the app
-NEXTAUTH_SESSION_COOKIE_SECRET=tokensecret # Random string for NextAuth cookies. Generate with `openssl rand -base64 32`
+# Domain where you serve the app
+NEXTAUTH_URL=http://localhost:3000
+# Random string for NextAuth cookies. Generate with `openssl rand -base64 32`
+NEXTAUTH_SESSION_COOKIE_SECRET=tokensecret
 
 ####################
 # Optional (local testing)


### PR DESCRIPTION
Closes #35

Merging this now since Pat is OOO

## Description

I uncovered two issues with setting up the next.js example while working on this:
1) In .env.example we had comments on the same line as env variables and this was causing an invalid URL error so I've moved them to separate lines to correct this

<img width="1087" alt="invalid URL" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/156c458d-6f71-4cb6-a9c2-861c7557f960">

2) I was constantly getting an error that was something like "redirect_uris must be a web address" and it was because if a client has redirect_uris that don't start with http or https (like localhost:3000 for example) then login will fail. This is obviously not ideal that our server is returning this so I'll create an issue for it 


## Screenshots

Next.js example working

<img width="469" alt="Screenshot 2023-05-22 at 4 12 18 PM" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/51d224aa-2aee-4505-bae2-ea4313aa9daf">

