### PR TITLE
Issue [SDK] 3 & 4: context provider & logging in

### DIFF
--- a/examples/next-app/pages/login.tsx
+++ b/examples/next-app/pages/login.tsx
@@ -8,10 +8,12 @@ import {
   Stack,
   Text,
 } from "@chakra-ui/react";
-import { useSession, signIn } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { FaDiscord, FaGoogle } from "react-icons/fa";
+// @ts-ignore
+import { signInKeyp } from "@usekeyp/js-sdk"
 
 const Login = () => {
   const [activeBtn, setActiveBtn] = useState<string>();
@@ -20,13 +22,6 @@ const Login = () => {
 
   console.log(session);
 
-  const handleGoogleLogin = () => {
-    signIn("keyp", undefined, "login_provider=GOOGLE");
-  };
-
-  const handleDiscordLogin = () => {
-    signIn("keyp", undefined, "login_provider=DISCORD");
-  };
 
   useEffect(() => {
     if (session && session.status === "authenticated") {
@@ -73,7 +68,7 @@ const Login = () => {
           >
             <Button
               variant="login"
-              onClick={() => handleGoogleLogin()}
+              onClick={() => signInKeyp("GOOGLE")}
               _hover={{
                 bg: "googleBlue",
                 color: "white",
@@ -103,7 +98,7 @@ const Login = () => {
           >
             <Button
               variant="login"
-              onClick={() => handleDiscordLogin()}
+              onClick={() => signInKeyp("DISCORD")}
               _hover={{
                 bg: "discordBlue",
                 color: "white",

--- a/packages/js-sdk/src/index.js
+++ b/packages/js-sdk/src/index.js
@@ -1,1 +1,2 @@
 export { KeypAuth } from "./keyp-auth";
+export { signInKeyp } from "./keyp-helpers";

--- a/packages/js-sdk/src/keyp-auth.js
+++ b/packages/js-sdk/src/keyp-auth.js
@@ -43,6 +43,7 @@ export const KeypAuth = (options) => {
                     token.username = profile.username;
                     token.address = profile.address;
                     token.sub = profile.sub;
+                    token.exp = profile.exp;
                 }
                 return token;
             },
@@ -53,6 +54,7 @@ export const KeypAuth = (options) => {
                     session.user.username = token.username;
                     session.user.address = token.address;
                     session.user.id = token.sub;
+                    session.user.exp = token.exp;
                 }
                 return session;
             },

--- a/packages/js-sdk/src/keyp-helpers.js
+++ b/packages/js-sdk/src/keyp-helpers.js
@@ -1,0 +1,8 @@
+import React from "react";
+import { signIn } from "next-auth/react";
+
+const signInKeyp = (provider) => {
+    signIn("keyp", undefined, `login_provider=${provider}`);
+};
+
+export { signInKeyp }


### PR DESCRIPTION
closes #37 and closes #38 

merging now since pat is OOO

As I mentioned in this PR (https://github.com/UseKeyp/usekeyp-js-sdk/pull/44) it's not feasible to wrap SessionProvider to manage the user object and session info because it creates a circular dependency between SessionProvider and KeypProvider, which are both doing the same thing. Rather than user.transfer for example we can simply create a transfer helper function that a user can easily import from the sdk to use our API. Also, rather than doing {user} = useKeyp() we can use the in-built useSession() hook to access the full user object 

## Description
- Created helper sign-in function called signInKeyp that takes a provider and logs a user in
- Expose the "exp" value which I'll use in a future issue for ensuring a user's session is active 


## Screenshots

custom sign-in function works and user object is properly exposed 

<img width="1227" alt="user is available" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/e1c47334-20de-4dee-a4e7-a622a37c3293">
