### PR TITLE
Issues 5 & 6 [SDK]: enable API calls & handle API authentication

### DIFF
--- a/examples/next-app/components/Wallet.tsx
+++ b/examples/next-app/components/Wallet.tsx
@@ -3,7 +3,9 @@ import axios from "axios";
 import { useSession } from "next-auth/react";
 import React, { useEffect, useState } from "react";
 import { UserBalance } from "types/keypEndpoints";
-import { KEYP_BASE_URL_V1, supportedAssets } from "utils/general";
+import { supportedAssets } from "utils/general";
+// @ts-ignore
+import { keypClient } from "@usekeyp/js-sdk";
 
 const Wallet = () => {
   const [assets, setAssets] = useState<UserBalance[] | undefined>();
@@ -41,13 +43,13 @@ const Wallet = () => {
       },
     };
 
-    const firstRequest = `${KEYP_BASE_URL_V1}/users/${userId}/balance`;
-    const secondRequest = `${KEYP_BASE_URL_V1}/users/${userId}/balance/${supportedAssets.DAI}`;
+    const firstRequest = `/users/${userId}/balance`;
+    const secondRequest = `/users/${userId}/balance/${supportedAssets.DAI}`;
 
     axios
       .all([
-        axios.get(firstRequest, options),
-        axios.get(secondRequest, options),
+        keypClient.get(firstRequest, options),
+        keypClient.get(secondRequest, options),
       ])
       .then(
         axios.spread((firstResponse, secondResponse) => {

--- a/packages/js-sdk/src/index.js
+++ b/packages/js-sdk/src/index.js
@@ -1,2 +1,4 @@
 export { KeypAuth } from "./keyp-auth";
 export { signInKeyp } from "./keyp-helpers";
+export { tokenTransferByUsername, tokenTransferByUserId } from "./token-helpers";
+export { keypClient } from "./keypClient";

--- a/packages/js-sdk/src/keyp-auth.js
+++ b/packages/js-sdk/src/keyp-auth.js
@@ -43,7 +43,6 @@ export const KeypAuth = (options) => {
                     token.username = profile.username;
                     token.address = profile.address;
                     token.sub = profile.sub;
-                    token.exp = profile.exp;
                 }
                 return token;
             },
@@ -54,7 +53,6 @@ export const KeypAuth = (options) => {
                     session.user.username = token.username;
                     session.user.address = token.address;
                     session.user.id = token.sub;
-                    session.user.exp = token.exp;
                 }
                 return session;
             },

--- a/packages/js-sdk/src/keypClient.js
+++ b/packages/js-sdk/src/keypClient.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { signOut } from 'next-auth/react';
+
+const keypClient = axios.create({
+    baseURL: 'https://api.usekeyp.com/v1',
+    headers: {
+        'Content-Type': 'application/json',
+    },
+});
+
+keypClient.interceptors.response.use(
+    response => {
+        return response;
+    },
+    error => {
+        if (error?.response?.status === 401) {
+            signOut();
+        }
+        return Promise.reject(error);
+    },
+);
+
+export { keypClient };

--- a/packages/js-sdk/src/token-helpers.js
+++ b/packages/js-sdk/src/token-helpers.js
@@ -1,0 +1,97 @@
+import { signOut } from "next-auth/react";
+import { keypClient } from "./keypClient";
+
+/**
+ * Transfers a token by user id
+ * @param {string} accessToken - The access token for authentication
+ * @param {string} amount - The amount of the token to transfer (for ERC20 tokens)
+ * @param {string} tokenId - The unique identifier of the token (for ERC721 tokens)
+ * @param {string} toAddress - The address of the recipient (either this or toUserId is required)
+ * @param {string} toUserId - The user id of the recipient in format PROVIDER-ID (either this or toAddress is required)
+ * @param {string} tokenType - The token type (e.g., 'ERC20', 'ERC721')
+ * @param {string} tokenAddress - The address of the token contract
+ * @returns {Object} The result of the transfer in the form { result, loading, error }
+ * @throws {string} If any of the required parameters are missing or incorrect
+ */
+const tokenTransferByUserId = async ({ accessToken, amount, tokenId, toAddress, toUserId, tokenType, tokenAddress }) => {
+    const headers = {
+        'Content-type': 'application/json',
+        Authorization: 'Bearer ' + accessToken,
+    };
+
+    if (!amount && tokenType === 'ERC20') throw 'Invalid amount'
+    if (!tokenId && tokenType === 'ERC721') throw 'Invalid tokenId'
+    if (!tokenAddress) throw 'Invalid token address'
+    if (!tokenType) throw 'Invalid token type'
+
+    try {
+        const response = await keypClient({
+            method: 'POST',
+            headers,
+            url: 'tokens/transfers',
+            data: {
+                amount,
+                toAddress,
+                toUserId,
+                tokenType,
+                tokenAddress,
+                tokenId,
+            },
+        });
+
+        return { result: response.data, loading: false, error: response.data.error };
+    } catch (error) {
+        if (error?.response?.status === 401) {
+            signOut();
+        }
+        return { result: null, loading: false, error: error };
+    }
+};
+
+/**
+ * Transfers a token by username
+ * @param {string} accessToken - The access token for authentication
+ * @param {string} amount - The amount of the token to transfer (for ERC20 tokens)
+ * @param {string} tokenId - The unique identifier of the token (for ERC721 tokens)
+ * @param {string} toUserUsername - The username of the recipient
+ * @param {string} toUserProviderType - The provider type for the recipient's username
+ * @param {string} tokenType - The token type (e.g., 'ERC20', 'ERC721')
+ * @param {string} tokenAddress - The address of the token contract
+ * @returns {Object} The result of the transfer in the form { result, loading, error }
+ * @throws {string} If any of the required parameters are missing or incorrect
+ */
+const tokenTransferByUsername = async ({ accessToken, amount, tokenId, toUserUsername, toUserProviderType, tokenType, tokenAddress }) => {
+    const headers = {
+        'Content-type': 'application/json',
+        Authorization: 'Bearer ' + accessToken,
+    };
+
+    if (!amount && tokenType === 'ERC20') throw 'Invalid amount'
+    if (!tokenId && tokenType === 'ERC721') throw 'Invalid tokenId'
+    if (!tokenAddress) throw 'Invalid token address'
+    if (!tokenType) throw 'Invalid token type'
+
+    try {
+        const response = await keypClient({
+            method: 'POST',
+            headers,
+            url: 'tokens/transfers',
+            data: {
+                amount,
+                toUserUsername,
+                toUserProviderType,
+                tokenType,
+                tokenAddress,
+            },
+        });
+
+        return { result: response.data, loading: false, error: response.data.error };
+    } catch (error) {
+        if (error?.response?.status === 401) {
+            signOut();
+        }
+        return { result: null , loading: false, error};
+    }
+};
+
+export { tokenTransferByUsername, tokenTransferByUserId };


### PR DESCRIPTION
Closes #39  and closes #40 

merging now since pat is OOO

Note on enabling token transfer calls:

I had tried to use a hook rather than helper functions for out token transfer helpers, however I'm still running into the issue of "dispatcher is null" whenever I use any React dependency in the SDK (like context, state, etc) which meant I had to go with the asynchronous option for now. If I can figure out why this is happening (maybe webpack causing duplicate rendering or transpiling issue?) then I might replace the functions with hooks but for now I think these helper functions are a good solution. 

Note on TS: 
I will have to convert these to typescript later but because I was running into transpiling issue when importing into the Next app and because there were a lot of untyped things in the SDK I'm just using JS for now. I'll try to convert everything to TS at the end to avoid having to suppress TS errors within the example app

## Description
- Created two helper functions for token transfers: tokenTransferByUserId and tokenTransferByUsername. To test I added the function to the next.js example app and created a button that would call the function and then print out the response to the console (I did not include this in the PR but it's in the screenshots below)

- Created axios wrapper called keypClient that allows us to intercept a 401 response and easily sign out a user with NextAuth. We can add more logic here in the future for custom responses to our API.

## Screenshots

Testing token transfer function response (failure) 

<img width="1373" alt="cannot send to self" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/0b898769-e321-404b-b0e4-acc801e99dc3">

Testing token transfer function response (failure) 

<img width="1061" alt="cannot find recipient" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/a2e35c27-c9eb-4de0-af1d-960f04714aa7">

Testing token transfer function response (success) 

<img width="1033" alt="success" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/49dd71a6-4d5f-45a5-a2f0-2090eff3da36">

keypClient successfully fetches wallet balance from API

<img width="1045" alt="keypClient" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/5458810b-d771-4348-af18-ff9964ba9466">

keypClient successfully logs out a user when the access token has expired (to test this I sign into my keyp account w/twitter on the same browser as the one I'm logged into kaching with already via discord and then I refresh the page)

https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/fac52952-525c-4823-802a-a2816193a959



