### PR TITLE
Issue #49: SDK Changes

### DIFF
--- a/examples/next-app/.env.example
+++ b/examples/next-app/.env.example
@@ -1,5 +1,5 @@
 # Your application Client ID from https://dev.usekeyp.com
-NEXT_PUBLIC_KEYP_CLIENT_ID=
+KEYP_CLIENT_ID=
 
 # Domain where you serve the app
 NEXTAUTH_URL=http://localhost:3000

--- a/examples/next-app/.env.example
+++ b/examples/next-app/.env.example
@@ -4,7 +4,7 @@ KEYP_CLIENT_ID=
 # Domain where you serve the app
 NEXTAUTH_URL=http://localhost:3000
 # Random string for NextAuth cookies. Generate with `openssl rand -base64 32`
-NEXTAUTH_SESSION_COOKIE_SECRET=tokensecret
+KEYP_COOKIE_SECRET=tokensecret
 
 ####################
 # Optional (local testing)

--- a/examples/next-app/pages/api/auth/[...nextauth].js
+++ b/examples/next-app/pages/api/auth/[...nextauth].js
@@ -2,8 +2,8 @@ import { KeypAuth } from "@usekeyp/js-sdk";
 import NextAuth from "next-auth";
 
 const NextAuthOptions = KeypAuth({
-    clientId: process.env.NEXT_PUBLIC_KEYP_CLIENT_ID, // From dev portal
-    secret: process.env.NEXT_PUBLIC_KEYP_COOKIE_SECRET, // Random string
+    clientId: process.env.KEYP_CLIENT_ID, // From dev portal
+    secret: process.env.KEYP_COOKIE_SECRET, // Random string
     redirectUrl: "http://localhost:3000/api/auth/callback/keyp",
 });
 

--- a/examples/next-app/types/keypEndpoints.ts
+++ b/examples/next-app/types/keypEndpoints.ts
@@ -20,7 +20,7 @@ export type UserBalance = {
 };
 
 export type TransferError = {
-  status: "FAILED" | "SUCCESS";
+  status: string;
   hash: string;
   error: string;
 };

--- a/examples/next-app/utils/general.ts
+++ b/examples/next-app/utils/general.ts
@@ -5,7 +5,6 @@ export const KEYP_BASE_URL_V1 = `${KEYP_API_DOMAIN}/v1`;
 export const blockExplorerLink = (hash: string) =>
   `https://polygonscan.com/tx/${hash}`;
 
-// TODO: replace ETH address with WETH on Polygon
 export const supportedAssets: { [k: string]: string } = {
   ETH: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
   DAI: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -23,8 +23,8 @@ Keyp's SDK provides a simple interface for interacting with Keyp's API.
 
 Currently, the SDK supports the following: 
 - A Keyp plugin for integration between Keyp and NextAuth.js (keyp-auth.ts)
-- Helper method for signing using Keyp and NextAuth.js (keyp-helpers.ts)
-- Helper methods for token transfers (token-helpers.ts)
+- Helper method for signing in using Keyp and NextAuth.js (keyp-helpers.ts)
+- Helper tokenTransfer method for token transfers (token-helpers.ts)
 - Axios client for easily making requests to Keyp's API (keypClient.ts)
 
 For an example of how to use the SDK, see the Next.js example app in the `examples` directory.

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -1,4 +1,4 @@
 export { KeypAuth } from "./keyp-auth";
 export { signInKeyp } from "./keyp-helpers";
-export { tokenTransferByUsername, tokenTransferByUserId } from "./token-helpers";
+export { tokenTransfer } from "./token-helpers";
 export { keypClient } from "./keypClient";

--- a/packages/js-sdk/src/keyp-auth.ts
+++ b/packages/js-sdk/src/keyp-auth.ts
@@ -1,6 +1,7 @@
 type Options = {
-    clientId: string;
-    secret?: string;
+    clientId: string | undefined;
+    secret?: string | undefined;
+    redirectUrl?: string | undefined;
 };
 
 type Profile = {


### PR DESCRIPTION
Closes #49 

## Description

Added everything we discussed on our call about SDK improvements last week. The only problem I ran into was doing the user.transferToken functionality, allowing access token to be passed in automatically. No matter how I passed in the tokenTransfer function to NextAuth it always filtered out the function from the user object. For example,
```
session.user.transferToken = (options) => transferToken({ accessToken: session.user.accessToken, ...options })
``` 
is always filtered out from the final user object in the app. I tried putting the transferToken function in other NextAuth callbacks as well but it always filtered out the function. I also created a TypeScript User class that had transferToken as one of its functions but it still filtered out the function from the user class. So, for now I think we have to pass in the access token until I can post this as a question in NextAuth's GH issues

- Created a general transferToken function that will route a transfer to the correct function (by username or by user ID) and included it in readme
- Logging in does not need NEXT_PUBLIC .env variables so I removed this from [...nextauth].js and the .env.example files
- I replaced the transfer token logic in the next example repo with the SDK's tranferToken function and tested 
- Changed token function responses to be in line with how our API returns responses (status, hash, error)
- Some lint fixes

## Screenshot

Token transfer works when using SDK function (this is using SPORK but it says ETH)

https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/f91cb8e2-ba18-47d8-ad74-43807be97c1b

Token transfer failure example when using SDK function (this is using SPORK but it says ETH)

https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/2b63a5e5-54c3-4eea-bc03-229c03b10656





