### PR TITLE
Issue #54: [SDK] Contract calls 

### DIFF
--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -25,6 +25,7 @@ Currently, the SDK supports the following:
 - A Keyp plugin for integration between Keyp and NextAuth.js (keyp-auth.ts)
 - Helper method for signing in using Keyp and NextAuth.js (keyp-helpers.ts)
 - Helper tokenTransfer method for token transfers (token-helpers.ts)
+- Helper readContract and writeContract methods for interacting with smart contracts (contract-helpers.ts)
 - Axios client for easily making requests to Keyp's API (keypClient.ts)
 
 For an example of how to use the SDK, see the Next.js example app in the `examples` directory.

--- a/packages/js-sdk/src/contract-helpers.ts
+++ b/packages/js-sdk/src/contract-helpers.ts
@@ -50,8 +50,6 @@ const readContract = async ({accessToken, address, abi, args}: ReadContractParam
         'Content-type': 'application/json',
         Authorization: 'Bearer ' + accessToken,
     };
-
-    try {
         const response: AxiosResponse = await keypClient.post('/contracts/method/read', {
             address: address,
             abi: abi,
@@ -59,16 +57,11 @@ const readContract = async ({accessToken, address, abi, args}: ReadContractParam
         }, {
             headers,
         });
-
         return {
             status: response.data.status,
             explorerUrl: response.data.explorerUrl,
             response: response.data.response,
         };
-    } catch (error) {
-        console.log(error.message, 'error')
-        return { status: 'FAILURE', explorerUrl: '', response: { type: '', hex: ''} };
-    }
 };
 
 /**
@@ -87,8 +80,6 @@ const writeContract = async ({accessToken, address, abi, args, value}: WriteCont
         'Content-type': 'application/json',
         Authorization: 'Bearer ' + accessToken,
     };
-
-    try {
         const response: AxiosResponse = await keypClient.post('/contracts/method/write', {
             address: address,
             abi: abi,
@@ -97,16 +88,12 @@ const writeContract = async ({accessToken, address, abi, args, value}: WriteCont
         }, {
             headers,
         });
-
         return {
             status: response.data.status,
             hash: response.data.hash,
             explorerUrl: response.data.explorerUrl,
             tx: response.data.tx,
         };
-    } catch (error) {
-        return { status: 'FAILURE', hash: '', explorerUrl: '', tx: { type: '', chainId: ''} };
-    }
 };
 
 export { readContract, writeContract };

--- a/packages/js-sdk/src/contract-helpers.ts
+++ b/packages/js-sdk/src/contract-helpers.ts
@@ -1,0 +1,114 @@
+import { keypClient } from "./keypClient";
+import { AxiosResponse } from 'axios';
+
+interface ReadContractParams {
+    accessToken?: string;
+    address?: string;
+    abi?: string;
+    args?: string[];
+}
+
+interface ReadContractResult {
+    status?: string;
+    explorerUrl?: string;
+    response?: {
+        type?: string;
+        hex?: string;
+    };
+}
+
+interface WriteContractParams {
+    accessToken?: string;
+    address?: string;
+    abi?: string;
+    args?: string[];
+    value?: string;
+}
+
+interface WriteContractResult {
+    status?: string;
+    hash?: string;
+    explorerUrl?: string;
+    tx?: {
+        type: number | string;
+        chainId: number | string;
+    }
+}
+
+/**
+ * Reads a contract method
+ * @param {string} accessToken - The access token for authentication
+ * @param {string} address - The address of the contract
+ * @param {string} abi - The ABI of the contract
+ * @param {string[]} args - The arguments for the contract method
+ */
+const readContract = async ({accessToken, address, abi, args}: ReadContractParams): Promise<ReadContractResult> => {
+    if (!accessToken) {
+        throw 'No access token provided';
+    }
+    const headers = {
+        'Content-type': 'application/json',
+        Authorization: 'Bearer ' + accessToken,
+    };
+
+    try {
+        const response: AxiosResponse = await keypClient.post('/contracts/method/read', {
+            address: address,
+            abi: abi,
+            args: args,
+        }, {
+            headers,
+        });
+
+        return {
+            status: response.data.status,
+            explorerUrl: response.data.explorerUrl,
+            response: response.data.response,
+        };
+    } catch (error) {
+        console.log(error.message, 'error')
+        return { status: 'FAILURE', explorerUrl: '', response: { type: '', hex: ''} };
+    }
+};
+
+/**
+ * Writes to a contract method
+ * @param {string} accessToken - The access token for authentication
+ * @param {string} address - The address of the contract
+ * @param {string} abi - The ABI of the contract
+ * @param {string[]} args - The arguments for the contract method
+ * @param {string} value - (Optional) Amount of network coin to send in units of wei
+ */
+const writeContract = async ({accessToken, address, abi, args, value}: WriteContractParams): Promise<WriteContractResult> => {
+    if (!accessToken) {
+        throw 'No access token provided';
+    }
+    const headers = {
+        'Content-type': 'application/json',
+        Authorization: 'Bearer ' + accessToken,
+    };
+
+    try {
+        const response: AxiosResponse = await keypClient.post('/contracts/method/write', {
+            address: address,
+            abi: abi,
+            args: args,
+            value: value,
+        }, {
+            headers,
+        });
+
+        return {
+            status: response.data.status,
+            hash: response.data.hash,
+            explorerUrl: response.data.explorerUrl,
+            tx: response.data.tx,
+        };
+    } catch (error) {
+        return { status: 'FAILURE', hash: '', explorerUrl: '', tx: { type: '', chainId: ''} };
+    }
+};
+
+export { readContract, writeContract };
+
+

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -1,4 +1,5 @@
 export { KeypAuth } from "./keyp-auth";
 export { signInKeyp } from "./keyp-helpers";
 export { tokenTransfer } from "./token-helpers";
+export { readContract, writeContract } from "./contract-helpers";
 export { keypClient } from "./keypClient";

--- a/packages/js-sdk/src/token-helpers.ts
+++ b/packages/js-sdk/src/token-helpers.ts
@@ -1,4 +1,3 @@
-import { signOut } from "next-auth/react";
 import { keypClient } from "./keypClient";
 import { AxiosResponse } from 'axios';
 
@@ -85,9 +84,6 @@ const tokenTransferByUserId = async ({
 
         return { status: response.data.status, hash: response.data.hash, error: response.data.error };
     } catch (error) {
-        if (error?.response?.status === 401) {
-            signOut();
-        }
         return { status: 'FAILURE', hash: '', error: error};
     }
 };
@@ -132,9 +128,6 @@ const tokenTransferByUsername = async ({ accessToken, amount, tokenId, toUserUse
 
         return { status: response.data.status, hash: response.data.hash, error: response.data.error };
     } catch (error) {
-        if (error?.response?.status === 401) {
-            signOut();
-        }
         return { status: 'FAILURE', hash: '', error: error};
     }
 };


### PR DESCRIPTION
Closes #54 

## Description
- Added helper methods for contract read and writes (readContract, writeContract)
- Removed catching 401s from the helper functions because keypClient already does this for us
- In the future we should consider adding an error field in our API like we have in /tokens so that we can return the cause of a server-side error to the user

## Screenshots

Read contract works (using docs params)

https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/7722c98f-8dab-472d-b6a8-9d1b0cd74670

Write contract works (using docs params)

https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/eb238cbc-3fde-4db2-90aa-b5e93d432c68


code I used for testing read & write (readContract and writeContract come from the SDK):

<img width="740" alt="testingreadandwrite" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/1262dd9b-db6e-494c-a05c-5d3ca047d280">




