### PR TITLE
Part of Issue #303: Improve contract endpoint error handling

### DIFF
--- a/packages/js-sdk/src/contract-helpers.ts
+++ b/packages/js-sdk/src/contract-helpers.ts
@@ -3,36 +3,38 @@ import { AxiosResponse } from 'axios';
 
 interface ReadContractParams {
     accessToken?: string;
-    address?: string;
-    abi?: string;
-    args?: string[];
+    address: string;
+    abi: string;
+    args: string[];
 }
 
 interface ReadContractResult {
-    status?: string;
+    status: string;
     explorerUrl?: string;
     response?: {
         type?: string;
         hex?: string;
     };
+    error?: string;
 }
 
 interface WriteContractParams {
     accessToken?: string;
-    address?: string;
-    abi?: string;
-    args?: string[];
+    address: string;
+    abi: string;
+    args: string[];
     value?: string;
 }
 
 interface WriteContractResult {
-    status?: string;
+    status: string;
     hash?: string;
     explorerUrl?: string;
     tx?: {
         type: number | string;
         chainId: number | string;
     }
+    error?: string;
 }
 
 /**
@@ -50,6 +52,7 @@ const readContract = async ({accessToken, address, abi, args}: ReadContractParam
         'Content-type': 'application/json',
         Authorization: 'Bearer ' + accessToken,
     };
+    try {
         const response: AxiosResponse = await keypClient.post('/contracts/method/read', {
             address: address,
             abi: abi,
@@ -62,6 +65,9 @@ const readContract = async ({accessToken, address, abi, args}: ReadContractParam
             explorerUrl: response.data.explorerUrl,
             response: response.data.response,
         };
+    } catch (error) {
+        return { status: 'FAILURE', explorerUrl: '', response: { type: '', hex: '' }, error: error };
+    }
 };
 
 /**
@@ -80,6 +86,7 @@ const writeContract = async ({accessToken, address, abi, args, value}: WriteCont
         'Content-type': 'application/json',
         Authorization: 'Bearer ' + accessToken,
     };
+    try {
         const response: AxiosResponse = await keypClient.post('/contracts/method/write', {
             address: address,
             abi: abi,
@@ -94,6 +101,9 @@ const writeContract = async ({accessToken, address, abi, args, value}: WriteCont
             explorerUrl: response.data.explorerUrl,
             tx: response.data.tx,
         };
+    } catch (error) {
+        return { status: 'FAILURE', hash: '', explorerUrl: '', tx: { type: '', chainId: '' }, error: error };
+    }
 };
 
 export { readContract, writeContract };

--- a/packages/js-sdk/src/token-helpers.ts
+++ b/packages/js-sdk/src/token-helpers.ts
@@ -2,7 +2,7 @@ import { keypClient } from "./keypClient";
 import { AxiosResponse } from 'axios';
 
 interface TokenTransferParams {
-    accessToken: string | undefined;
+    accessToken?: string;
     amount?: string;
     tokenId?: string;
     toAddress?: string;


### PR DESCRIPTION
part of this PR: https://github.com/UseKeyp/keyp-app/pull/306

## Description
- Edit TS types to add optional error field, make certain fields mandatory that were nullable before
- Add try/catch similar to /tokens helpers


## Screenshots

Transfer error (no helpful error message yet because testing against prod)

<img width="1140" alt="transfer error" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/0c8da56f-cd20-4055-aa61-0f78c774dfbe">

Test write contract success

<img width="1149" alt="test write contract" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/ce6c308a-a89e-43bc-ac05-e566d37962f2">


