### PR TITLE
Issue #66: Next app fails on yarn install 

### DIFF
--- a/examples/next-app/package.json
+++ b/examples/next-app/package.json
@@ -45,6 +45,6 @@
     "tailwindcss": "^3.3.2"
   },
   "resolutions": {
-    "@usekeyp/js-sdk": "portal:/home/dev/repos/keyp/usekeyp-js-sdk/packages/js-sdk"
+    "@usekeyp/js-sdk": "0.1.7"
   }
 }

--- a/examples/next-app/package.json
+++ b/examples/next-app/package.json
@@ -19,7 +19,7 @@
     "@types/node": "18.11.18",
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.10",
-    "@usekeyp/js-sdk": "^0.1.6",
+    "@usekeyp/js-sdk": "^0.1.7",
     "@usekeyp/ui-kit": "0.1.6",
     "axios": "^1.2.3",
     "cheerio": "^1.0.0-rc.12",
@@ -43,8 +43,5 @@
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.24",
     "tailwindcss": "^3.3.2"
-  },
-  "resolutions": {
-    "@usekeyp/js-sdk": "0.1.7"
   }
 }

--- a/examples/next-app/yarn.lock
+++ b/examples/next-app/yarn.lock
@@ -5886,7 +5886,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@usekeyp/js-sdk@npm:0.1.7":
+"@usekeyp/js-sdk@npm:^0.1.7":
   version: 0.1.7
   resolution: "@usekeyp/js-sdk@npm:0.1.7"
   dependencies:
@@ -13028,7 +13028,7 @@ __metadata:
     "@types/node": 18.11.18
     "@types/react": 18.0.26
     "@types/react-dom": 18.0.10
-    "@usekeyp/js-sdk": ^0.1.6
+    "@usekeyp/js-sdk": ^0.1.7
     "@usekeyp/ui-kit": 0.1.6
     autoprefixer: ^10.4.14
     axios: ^1.2.3

--- a/examples/next-app/yarn.lock
+++ b/examples/next-app/yarn.lock
@@ -5886,9 +5886,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@usekeyp/js-sdk@portal:/home/dev/repos/keyp/usekeyp-js-sdk/packages/js-sdk::locator=kaching%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@usekeyp/js-sdk@portal:/home/dev/repos/keyp/usekeyp-js-sdk/packages/js-sdk::locator=kaching%40workspace%3A."
+"@usekeyp/js-sdk@npm:0.1.7":
+  version: 0.1.7
+  resolution: "@usekeyp/js-sdk@npm:0.1.7"
   dependencies:
     "@redwoodjs/router": ^3.3.0
     next-auth: ^4.22.1
@@ -5896,8 +5896,9 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-scripts: 5.0.1
+  checksum: f7f9c38c5c09b3a83980016834add6b3f4162d99ca9898eb4f24f056bc465cc49147a4d4a5da88499ce64c92e161acd24924d2a971e5cf0d8db11ce8751be23b
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@usekeyp/ui-kit@npm:0.1.6":
   version: 0.1.6


### PR DESCRIPTION
closes #66 

## Description

next app fails on install because resolutions is looking at a public path but the published sdk version is specified in dependencies 

- removed resolutions part of next app package.json
- bumped sdk version to latest

## Screenshots

Before

<img width="1217" alt="incorrect config" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/600db424-5abf-4cf4-9996-88d51688f0b7">
