### PR TITLE
Issue #57: [SDK] React dependencies 

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -13,14 +13,6 @@
     "pre-publish": "yarn build",
     "build": "tsc"
   },
-  "dependencies": {
-    "@redwoodjs/router": "^3.3.0",
-    "next-auth": "^4.22.1",
-    "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1"
-  },
   "devDependencies": {
     "@babel/cli": "^7.21.0",
     "@babel/core": "^7.21.4",
@@ -43,5 +35,13 @@
     "type": "git",
     "url": "git+https://github.com/UseKeyp/usekeyp-js-sdk.git"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "peerDependencies": {
+    "@redwoodjs/router": "^3.3.0",
+    "next-auth": "^4.22.1",
+    "prop-types": "^15.8.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  }
 }


### PR DESCRIPTION
Closes #57 

## Description

Made the React dependencies in the SDK package.json peerDependencies instead of dependencies and tested. no errors and logins and transfers still work

note: this only works locally once I apply the fix in https://github.com/UseKeyp/usekeyp-js-sdk/issues/66

## Screenshots

Token transfers work (I removed client-side validation temporarily to send 0 erc20 via polygon)

<img width="1412" alt="transaction sent" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/23481aba-3ee3-4df6-9921-0b4a299423a2">

