### PR TITLE
Issue #64: [SDK] Error messaging for unauthorized users

### DIFF
--- a/packages/js-sdk/src/keypClient.ts
+++ b/packages/js-sdk/src/keypClient.ts
@@ -17,7 +17,9 @@ keypClient.interceptors.response.use(
     },
     error => {
         if (error?.response?.status === 401) {
-            signOut();
+            if (typeof window !== 'undefined') {
+                signOut();
+            }
         }
         return Promise.reject(error);
     },

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
-    "lib": ["es2022"],
+    "lib": [
+      "es2022",
+      "dom"
+    ],
     "module": "commonjs",
     "target": "es2022",
     "moduleResolution": "node",


### PR DESCRIPTION
closes #64 

## Description
- Now we check to see if window is undefined before calling signOut (we need a browser environment to sign out the user) but now API calls using our axios client shouldn't throw errors
- To change the error messaging from "Unauthorized" I would need to modify keyp-app's middleware.js:

<img width="742" alt="unauthorized error message" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/e9c0ebfd-e1e1-443a-807b-38ca0072f8b2">

what do you think about me changing this messaging to be "Unauthorized: Invalid access token or forbidden"?

## Screenshots

Checking if window exists prevents "window is undefined" error from being thrown (photo 1/2)

<img width="1147" alt="check if window exists" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/ed393d30-ae2f-4698-87f7-f57099c76f1a">

No "window is undefined" error thrown at end of error response (photo 2/2)

<img width="443" alt="no error at end of response" src="https://github.com/UseKeyp/usekeyp-js-sdk/assets/47253537/a37dd179-dec7-4f99-95ca-ff2709e201e7">
